### PR TITLE
Removed console.log

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -265,7 +265,6 @@
 				})
 
 				editor.container.addClass('pos-relative');
-				console.log(editor.container);
 			});
 
 


### PR DESCRIPTION
One of users reported that CKEditor adds strange things to the console. Turned out that's because of this `console.log()` call.