### PR TITLE
Make floating tools compatible with inline (contenteditable) editors

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -329,8 +329,8 @@
 			 */
 			set_mousepos = function(data) {
 				editor.floatingtools.mousepos = {
-					left: data.clientX,
-					top: data.clientY
+					left: data.offsetX,
+					top: data.offsetY
 				};
 			}
 
@@ -362,8 +362,7 @@
 			 */
 			get_editor_offset = function() {
 				if (! editor.floatingtools.editoroffset) {
-					var editor_id = editor.ui.spaceId( 'contents' );
-					var obj = CKEDITOR.document.getById( editor_id );
+					var obj = editor.element;
 					editor.floatingtools.editoroffset = {
 						left:   obj.$.offsetLeft,
 						top:    obj.$.offsetTop,


### PR DESCRIPTION
Includes changes for mouse position and editor offset calculations (use offsetX/Y for mouse position (instead of clientX/Y) to keep it relative to inline editor, use `editor.element` to get editor instance and establish initial offsets instead of `editor.ui.spaceId`). I didn’t test it with the classic iframe-based editor instances, and it still isn’t perfect, but it gets the plugin closer and prevents JS errors.

Intended to fix #5